### PR TITLE
Add header prefix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## Summary
+### Summary
 
 Summary of the PR here. The GitHub release description is created from this comment so keep it nice and descriptive.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         version: ${{ steps.context.outputs.new-version }}
         body: ${{ steps.context.outputs.pr-body }}
         pr-url: ${{ steps.context.outputs.pr-url }}
+        header-prefix: '##'
     - name: Create GitHub Release
       if: ${{ steps.context.outputs.should-publish == 'true' }}
       uses: woksin-org/github-release-action@v3

--- a/Source/action.ts
+++ b/Source/action.ts
@@ -23,8 +23,9 @@ export async function run() {
         const changelogPath = getInput('changelog-path', { required: false });
         const userEmail = getInput('user-email', { required: false });
         const userName = getInput('user-name', { required: false });
+        const headerPrefix = getInput('header-prefix', { required: false });
         logger.info(`Creating new content for changelog with version ${version}`);
-        const content = createChangelogContent(body, version, prUrl);
+        const content = createChangelogContent(body, version, prUrl, headerPrefix);
         logger.info(`Writing to path ${changelogPath} with heading ${content[0]} and ${content.length} lines of new content`);
         writeToFile(changelogPath, content);
         logger.info('Write complete');
@@ -45,9 +46,9 @@ function fail(error: Error) {
     setFailed(error.message);
 }
 
-function createChangelogContent(body: string, version: string, prUrl?: string): string[] {
+function createChangelogContent(body: string, version: string, prUrl: string, headerPrefix: string): string[] {
     const date = new Date(new Date().toUTCString());
-    let heading = `# [${version}] - ${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate()}`;
+    let heading = `${headerPrefix} [${version}] - ${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate()}`;
     if (prUrl) {
         const prNumber = prUrl.slice(prUrl.indexOf('pull/')).match(/\d+$/);
         heading += `[PR: #${prNumber}](${prUrl})`;

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: The name of the user that commits the CHANGELOG
     required: false
     default: github-actions[bot]
+  header-prefix:
+    description: The prefix to be added to the Version header
+    required: false
+    default: '#'
 
 runs:
   using: 'node16'


### PR DESCRIPTION
### Added

- `header-prefix` input that is the prefix of the version header appended to the changelog. By default this is `#`