### PR TITLE
Add space and remove 'PR:' from the heading

### DIFF
--- a/Source/action.ts
+++ b/Source/action.ts
@@ -50,7 +50,7 @@ function createChangelogContent(body: string, version: string, prUrl?: string): 
     let heading = `# [${version}] - ${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate()}`;
     if (prUrl) {
         const prNumber = prUrl.slice(prUrl.indexOf('pull/')).match(/\d+$/);
-        heading += `[PR: #${prNumber}](${prUrl})`;
+        heading += ` [#${prNumber}](${prUrl})`;
     }
 
     const splitBody = body.split('\n');


### PR DESCRIPTION
## Summary

Fixes the heading format

### Fixed

- Adds a missing space in the heading
- Remove the 'PR:' text, just kepp the #\<PR number\>
